### PR TITLE
Fill map different widths with spaces

### DIFF
--- a/cub3d-master/Makefile
+++ b/cub3d-master/Makefile
@@ -6,7 +6,7 @@
 #    By: lfranca- <lfranca-@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/08/10 18:12:04 by cleticia          #+#    #+#              #
-#    Updated: 2022/12/08 21:46:29 by lfranca-         ###   ########.fr        #
+#    Updated: 2022/12/09 11:12:48 by lfranca-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -28,6 +28,8 @@ SRC = src/cub/main.c\
 	src/cub/game_loop.c\
 	src/cub/paint_frame/color_bg.c\
 	src/cub/paint_frame/paint_scene.c\
+	src/cub/map_validation/prepare_to_store.c\
+	src/cub/map_validation/measure_map.c\
 	src/cub/map_validation/store_map.c\
 	src/cub/map_validation/store_texture_rgb.c\
 	src/cub/map_validation/store_utils.c\

--- a/cub3d-master/inc/cub3d.h
+++ b/cub3d-master/inc/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: lfranca- <lfranca-@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/10 18:15:32 by cleticia          #+#    #+#             */
-/*   Updated: 2022/12/09 08:14:33 by lfranca-         ###   ########.fr       */
+/*   Updated: 2022/12/09 10:41:02 by lfranca-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 # define FT_SUCCESS 0
 # define SCREEN_WIDTH 800
 # define SCREEN_HEIGHT 600
+# define SMALLER_THAN_MAP_SIZE 1 //pra armazenamento do mapa
 
 # include <math.h>
 # include <stdio.h>
@@ -66,7 +67,7 @@ typedef struct s_3dmap
 typedef struct s_ray
 {
 	char	*rays; //orientacao
-	int	index;
+	int		index;
 	double	dir_x; //vetor de direcao inicial eixo x
 	double	dir_y; //vetor de direcao inicial eixo y
 	float 	ray_x; //posiciao inicial do raio rx e ry
@@ -76,29 +77,29 @@ typedef struct s_ray
 	float	gamer_angle; //pa
 	float	deltax;//pdx; //delta x
 	float 	deltay;//pdy; //delta y
-	int	x;
-	int	map_x; //posicao atual
-	int	map_y;
+	int		x;
+	int		map_x; //posicao atual
+	int		map_y;
 	float 	step_x; //comprimento inicial interno da celula xo
-    	float 	step_y; //comprimento final interno da celula yo
-	int	*rgb;
-	int	depth_of_field; //dof
+    float 	step_y; //comprimento final interno da celula yo
+	int		*rgb;
+	int		depth_of_field; //dof
 	float	ray_angle;
 	float 	neg_tan; //ntan negativo da tangente
 	float 	neg_inv_tan; //atan negativo do invers
 	float 	dist_horizontal; //dish;
 	float 	dist_vertical; //disv;
 	float	dist_final;
-        t_col   collision;
+    t_col   collision;
 }	t_ray;
 
 typedef struct s_background
 {
 	void	*ptr_img; //ptr_map
-	int	*data;
-	int	line_size;
-	int	bpp;
-	int	endian;
+	int		*data;
+	int		line_size;
+	int		bpp;
+	int		endian;
 }	t_background;
 
 typedef struct s_mlx
@@ -109,12 +110,12 @@ typedef struct s_mlx
 
 typedef	struct s_image
 {// abaixo: as texturas das paredes e os numeros rgb
-	char	*east_wall;//strings dos caminhos
-	char	*west_wall;
-	char	*north_wall;
-	char	*south_wall;
-	int	width;
-	int 	height;
+	char			*east_wall;//strings dos caminhos
+	char			*west_wall;
+	char			*north_wall;
+	char			*south_wall;
+	int				width;
+	int 			height;
 	t_background	east_tile;
 	t_background	west_tile;
 	t_background	north_tile;
@@ -123,20 +124,21 @@ typedef	struct s_image
 
 typedef struct s_map //principal
 {
-	t_mlx	mlx;
-	t_image	textures;
+	t_mlx			mlx;
+	t_image			textures;
 	t_background	back;
 	t_background	map2d;
 	t_background	gamer;
-	t_ray	rays;
-	char	**map;
-	char	*floor;
-	char	*ceilling;
-	int	monitoring;
-	int	height; //map_y -altura
-	int	width; //map_x -largura
-	int	fd;
-	char	spawing;
+	t_ray			rays;
+	char			**map;
+	char			*floor;
+	char			*ceilling;
+	int				monitoring;
+	int				is_squared_map;
+	int				height; //map_y -altura
+	int				width; //map_x -largura
+	int				fd;
+	char			spawing;
 }	t_map;
 
 enum e_keycode
@@ -153,10 +155,10 @@ enum e_keycode
 	X_EVENT_KEY_PRESS	= 2
 };
 
-int    count_height_width(char *line, t_map *map);
-void    check_textures_rgb(char *line, int *monitoring);
-void    draw_wall_strip(t_3dmap *map_3D, t_background *backg, t_ray *rays, int rays_counter);
-int     check_smaller_ray(t_ray *rays, float *horiz_position, float *vert_position);
+int		count_height_width(char *line, t_map *map);
+void	check_textures_rgb(char *line, int *monitoring);
+void	draw_wall_strip(t_3dmap *map_3D, t_background *backg, t_ray *rays, int rays_counter);
+int		check_smaller_ray(t_ray *rays, float *horiz_position, float *vert_position);
 void    fix_fish_eye(t_ray *rays);
 void	keep_angle_limits(float *ray_angle);
 void    draw_3d(t_ray *ray, float dist_final, int rays_counter, t_map *map);
@@ -170,14 +172,14 @@ void    move_gamer(char **map, t_ray *rays, char *movement);
 int		open_texture(t_mlx *mlx, t_background *tile, int *coord, char *path);
 int		textures_init(t_image *textures, t_mlx *mlx);
 float	measure_ray_dist(float beginX, float beginY, float endX, float endY);
-int	minimize_window(t_map *map);
-int	end_program(t_map *map);
-int	encode_rgb(uint8_t red, uint8_t green, uint8_t blue);
+int		minimize_window(t_map *map);
+int		end_program(t_map *map);
+int		encode_rgb(uint8_t red, uint8_t green, uint8_t blue);
 int     draw_ray_2d(t_ray *rays, t_background *map2d, int map_width, int color);
 void	cast_rays(t_map *map);
 void	paint_gamer(t_map *map);
 void	paint_map(t_map *map);
-int	event_key(int keycode, t_map *map);
+int		event_key(int keycode, t_map *map);
 void	move_player(t_map *map, int x, int y);
 void	draw_stripe(t_map *map);
 void	check_color(t_map *map);

--- a/cub3d-master/src/cub/map_validation/measure_map.c
+++ b/cub3d-master/src/cub/map_validation/measure_map.c
@@ -1,0 +1,101 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   measure_map.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfranca- <lfranca-@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/12/09 11:07:50 by lfranca-          #+#    #+#             */
+/*   Updated: 2022/12/09 11:08:45 by lfranca-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../../inc/cub3d.h"
+
+void    check_textures_rgb(char *line, int *monitoring)
+{
+	static int  texture;
+	static int  rgb;
+
+	if (ft_strchr(line, '.')) //texturas
+	{
+		texture++;
+		if (texture == TEXTURES_DONE)
+			(*monitoring) += 4;
+	}
+	else if (ft_strchr(line, ','))//floor e ceilling
+	{
+		rgb++;
+		if(rgb == RGB_DONE)
+			(*monitoring ) += 2;//significa que passou pelo rgb
+	}
+}
+
+// a gente pode usar essa função pra monitor se o tamanho das linhas é
+// diferente em relação uma à outra:
+// caso o map->width seja != 0 (se não tiver essa guarda, ele pode
+// acabar entendendo que as linhas do mapa tem largura diferente, sendo
+// que é só a PRIMEIRA VEZ que ele tá guardando (no inicio, map->width = 0))
+// então.. caso map->width != 0 e é também != size que acabou de ser tirado,
+// então significa que as linhas tem tamanhos diferentes.
+// Senão, por enquanto está sendo um mapa quadrado.
+// Mas o ponto é:
+// usa isso pra monitorar e RETORNA ESSE valor (verdadeiro pra se o mapa é quadrado,
+// falso pra sinalizar que não é - e precisa ter suas linhas preenchidas com espaço).
+// Quando voltar pra measure_height(), caso o retorno da count_height_width seja a
+// de que o mapa NÃO É QUADRADO, na hora de ARMAZENAR O MAPA, sempre comparar o tamanho
+// de cada linha com a da width total, e aquelas que forem menores, serem
+// PREENCHIDAS/AJUSTADAS antes de serem gravadas na matriz do mapa.
+// provavelmente vai ter que inserir essa variável (is_map_squared) na struct map pra poder repassar
+// 
+int    count_height_width(char *line, t_map *map)
+{
+	int		size;
+
+	if (map->monitoring != 6)
+	{
+		free(line);
+		return (505); //wrong formating
+	}
+	map->height++;
+	size = ft_strlen(line);
+	// verificamos se as linhas tem tamanhos diferentes (o mapa não é quadrado)
+	if (map->width != 0 && size != map->width)
+		map->is_squared_map = 0;
+	if(size > map->width)
+		map->width = size;
+	return (0);
+}
+
+/*
+** measure_height() vai tirar a altura da matriz do mapa (que servirá para o minimapa e
+** para projetar o mapa 3d tambem).
+*/
+int	measure_height(char **line, t_map *map)
+{
+	int		ret;
+
+	ret = 1;
+	while (ret)
+	{
+        if (line && (*line))
+            free(*line);
+		ret = get_next_line(map->fd, line);
+		if (ret == 0 && map->height == 0 && map->monitoring == 0)
+			return (505);
+ 		if (ft_strchr(*line, '.') || ft_strchr(*line, ','))
+            check_textures_rgb(*line, &map->monitoring);
+		else if(is_empty_line(*line) && map->height == 0)
+			continue;
+		else if (count_height_width(*line, map) == 505)
+			return (505);
+	}
+	if (*line)
+		free(*line);
+	if (map->height == 0)
+	{
+		close(map->fd);
+		return (505);
+	}
+	return (0);
+}

--- a/cub3d-master/src/cub/map_validation/prepare_to_store.c
+++ b/cub3d-master/src/cub/map_validation/prepare_to_store.c
@@ -1,0 +1,103 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   prepare_to_store.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfranca- <lfranca-@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/08/30 16:48:18 by cleticia          #+#    #+#             */
+/*   Updated: 2022/12/09 11:13:17 by lfranca-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../../inc/cub3d.h"
+
+/*
+** Verifica se a linha lida é correspondente a uma "linha vazia" (ou porque só
+** tem o caracter nulo ou porque tem espaços/tabs mas mais nada. É por isso
+** que trimá-la faz parte do processo de verificação também. Afinal, caso ela
+** tenha "conteúdo" - espaços e/ou tabs - se for só isso, ela ainda deve ser
+** considerada vazia).
+** É importante fazer essa verificação porque, caso seja uma linha vazia
+** ANTES DO MAPA, podemos "pular ela" - continuar para a próxima
+** iteração/linha.
+*/
+int is_empty_line(char *line)
+{
+	char *trimmed_line;
+
+	trimmed_line = NULL;
+	if (ft_strlen(line) == 0)
+		return (1);
+	trimmed_line = ft_strtrim(line, " \t");
+	if (ft_strlen(trimmed_line) == 0)
+	{
+		free(trimmed_line);
+		return (1);
+	}
+	free(trimmed_line);
+	return (0);
+}
+
+static void init_map(t_map *map)
+{
+	map->map = NULL;
+	map->floor = NULL;
+	map->ceilling = NULL;
+	map->monitoring = 0;
+	map->height = 0;
+	map->width = 0;
+	map->fd = 0;
+	map->spawing = 0;
+	map->is_squared_map = 1;
+	map->textures.east_wall = NULL;
+	map->textures.west_wall = NULL;
+	map->textures.north_wall = NULL;
+	map->textures.south_wall = NULL;
+}
+
+static void alloc_zero_map(t_map *map)
+{
+	int counter;
+
+	counter = 0;
+	map->map = malloc(sizeof(char *) * (map->height + 1));
+	while (counter < map->height)
+	{
+		map->map[counter] = NULL;
+		counter++;
+	}
+	map->map[map->height] = NULL;
+}
+
+t_map	*prepare_to_store(char *filename)
+{
+	t_map	*map;
+	char	*line;
+
+	line = NULL;
+	map = malloc(sizeof(t_map));
+	init_map(map);
+	map->fd = open(filename, O_RDONLY);
+	if (map->fd == -1)
+	{
+		free(map);
+        file_error("Error\nFailed to open map file.", 5);
+	}
+	if (measure_height(&line, map) == 505)
+	{
+		free(map);
+		file_error("Error\nEmpty file or Map must on the end of file", 505);
+	}
+	alloc_zero_map(map);
+	if (store_file_content(&line, map, filename) == 303)
+		map_error(map);
+	close(map->fd);
+	return (map);
+}
+
+
+/*
+./cub3d ./src/maps/map.cub
+./cub3d ./src/maps/map3.cub
+*/


### PR DESCRIPTION
- If the map isn't rectangular (has lines of different sizes), it fills them with spaces to the extent of the map_size (which is the length of the bigger line).
- Renames the file "store_map()" to "prepare_to_store()" and moves the store_file_content() functions to a new file called "store_map()"